### PR TITLE
Add Username to Tab Bar

### DIFF
--- a/winston/Tabber.swift
+++ b/winston/Tabber.swift
@@ -69,10 +69,8 @@ struct Tabber: View {
         .tabItem {
           VStack {
             Image(systemName: "person.fill")
-              if let me = redditAPI.me {
-                  if let data = me.data {
-                      Text(showUsernameInTabBar ? data.name : "Me")
-                  }
+              if showUsernameInTabBar, let me = redditAPI.me, let data = me.data {
+                  Text(data.name)
               } else {
                   Text("Me")
               }

--- a/winston/Tabber.swift
+++ b/winston/Tabber.swift
@@ -43,7 +43,7 @@ struct Tabber: View {
     .settings: true,
   ]
   @Default(.postsInBox) var postsInBox
-  
+  @Default(.showUsernameInTabBar) var showUsernameInTabBar
   var body: some View {
     TabView(selection: $activeTab.onUpdate { newTab in if activeTab == newTab { reset[newTab]!.toggle() } }) {
       
@@ -69,7 +69,13 @@ struct Tabber: View {
         .tabItem {
           VStack {
             Image(systemName: "person.fill")
-            Text("Me")
+              if let me = redditAPI.me {
+                  if let data = me.data {
+                      Text(showUsernameInTabBar ? data.name : "Me")
+                  }
+              } else {
+                  Text("Me")
+              }
           }
         }
         .tag(TabIdentifier.me)

--- a/winston/globals/defaults.swift
+++ b/winston/globals/defaults.swift
@@ -62,6 +62,8 @@ extension Defaults.Keys {
   static let maxPostLinkImageHeightPercentage = Key<Double>("maxPostLinkImageHeightPercentage", default: 100)
   static let replyModalBlurBackground = Key<Bool>("replyModalBlurBackground", default: true)
   static let newPostModalBlurBackground = Key<Bool>("newPostModalBlurBackground", default: true)
+  static let showUsernameInTabBar =
+    Key<Bool>("showUsernameInTabBar", default: true)
   static let openYoutubeApp = Key<Bool>("openYoutubeApp", default: true)
   static let showHomeFeed = Key<Bool>("showHomeFeed", default: true)
   static let showPopularFeed = Key<Bool>("showPopularFeed", default: true)

--- a/winston/views/Settings/views/AppearancePanel.swift
+++ b/winston/views/Settings/views/AppearancePanel.swift
@@ -13,6 +13,7 @@ struct AppearancePanel: View {
   @Default(.preferenceShowCommentsAvatars) var preferenceShowCommentsAvatars
   @Default(.replyModalBlurBackground) var replyModalBlurBackground
   @Default(.newPostModalBlurBackground) var newPostModalBlurBackground
+  @Default(.showUsernameInTabBar) var showUsernameInTabBar
   
   @Default(.preferenceShowPostsCards) var preferenceShowPostsCards
   @Default(.preferenceShowCommentsCards) var preferenceShowCommentsCards
@@ -39,6 +40,8 @@ struct AppearancePanel: View {
       Section("General") {
         Toggle("Blur reply background", isOn: $replyModalBlurBackground)
         Toggle("Blur new post background", isOn: $newPostModalBlurBackground)
+          Toggle("Show Username in Tabbar", isOn: $showUsernameInTabBar)
+        
       }
       
       Section("Posts") {


### PR DESCRIPTION
This adds the username to the tab bar instead of the "Me" because it looks nicer and may be useful if the app supports multiple accounts in the future.