### PR TITLE
add lastActivities update call to refreshable modifier inside userview

### DIFF
--- a/winston/views/UserView.swift
+++ b/winston/views/UserView.swift
@@ -138,7 +138,16 @@ struct UserView: View {
     }
     .listStyle(.plain)
     .refreshable {
-      await refresh()
+        await refresh()
+        
+        if let data = await user.refetchOverview() {
+          DispatchQueue.main.async { // fetching posts on non-main thread
+            withAnimation {
+              lastActivities = data
+            }
+          }
+          await user.redditAPI.updateAvatarURLCacheFromOverview(subjects: data)
+        }
     }
     .navigationTitle(user.data?.name ?? "Loading...")
     .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
- Refreshing your profile after you post a comment currently doesn't populate with your new comment. This PR fixes that.
- lastActivities gets updated with data on an async thread to populate profile with latest data