### PR TITLE
Add integrated browser

### DIFF
--- a/winston/components/DeaultDestinationInjector.swift
+++ b/winston/components/DeaultDestinationInjector.swift
@@ -47,6 +47,12 @@ struct DefaultDestinationInjector<Content: View>: View {
         UserView(user: user)
           .environmentObject(routerProxy)
       }
+      .navigationDestination(for: SafariViewPayload.self) { payload in
+        SafariView(payload: payload)
+          .frame(maxHeight: .infinity)
+          .navigationBarTitleDisplayMode(.inline)
+          .environmentObject(routerProxy)
+      }
       .environmentObject(routerProxy)
   }
 }

--- a/winston/components/Media/PreviewLink/PreviewLinkContent.swift
+++ b/winston/components/Media/PreviewLink/PreviewLinkContent.swift
@@ -120,7 +120,7 @@ struct PreviewLinkContent: View {
   var url: URL
   static let height: CGFloat = 88
   @Environment(\.openURL) var openURL
-  @EnvironmentObject private var router: Router
+  @EnvironmentObject private var routerProxy: RouterProxy
   @Default(.useIntegratedBrowser) private var useIntegratedBrowser
   @Default(.defaultReaderMode) private var defaultReaderMode
 
@@ -188,7 +188,7 @@ struct PreviewLinkContent: View {
     }
     .highPriorityGesture(TapGesture().onEnded {
       if useIntegratedBrowser {
-        router.path.append(SafariViewPayload(url: url, useReader: defaultReaderMode))
+        routerProxy.router.path.append(SafariViewPayload(url: url, useReader: defaultReaderMode))
         return
       }
       if let newURL = URL(string: url.absoluteString.replacingOccurrences(of: "https://reddit.com/", with: "winstonapp://")) {

--- a/winston/components/Media/PreviewLink/PreviewLinkContent.swift
+++ b/winston/components/Media/PreviewLink/PreviewLinkContent.swift
@@ -120,7 +120,10 @@ struct PreviewLinkContent: View {
   var url: URL
   static let height: CGFloat = 88
   @Environment(\.openURL) var openURL
-  
+  @EnvironmentObject private var router: Router
+  @Default(.useIntegratedBrowser) private var useIntegratedBrowser
+  @Default(.defaultReaderMode) private var defaultReaderMode
+
   var body: some View {
     HStack(spacing: 16) {
       
@@ -184,6 +187,10 @@ struct PreviewLinkContent: View {
       }
     }
     .highPriorityGesture(TapGesture().onEnded {
+      if useIntegratedBrowser {
+        router.path.append(SafariViewPayload(url: url, useReader: defaultReaderMode))
+        return
+      }
       if let newURL = URL(string: url.absoluteString.replacingOccurrences(of: "https://reddit.com/", with: "winstonapp://")) {
         openURL(newURL)
       }

--- a/winston/globals/defaults.swift
+++ b/winston/globals/defaults.swift
@@ -106,6 +106,9 @@ extension Defaults.Keys {
   static let showSubsAtTop = Key<Bool>("showSubsAtTop", default: false)
   static let showTitleAtTop = Key<Bool>("showTitleAtTop", default: true)
   
+  static let useIntegratedBrowser = Key<Bool>("useIntegratedBrowser", default: false)
+  static let defaultReaderMode = Key<Bool>("defaultReaderMode", default: false)
+  
   static let postLinkTitleSize = Key<CGFloat>("postLinkTitleSize", default: 16)
   static let postLinkBodySize = Key<CGFloat>("postLinkBodySize", default: 14)
   static let postViewTitleSize = Key<CGFloat>("postViewTitleSize", default: 20)

--- a/winston/modifiers/defaultNavDestinations.swift
+++ b/winston/modifiers/defaultNavDestinations.swift
@@ -45,6 +45,12 @@ extension View {
         UserView(user: user)
           .environmentObject(router)
       }
+      .navigationDestination(for: SafariViewPayload.self) { payload in
+        SafariView(payload: payload)
+          .frame(maxHeight: .infinity)
+          .navigationBarTitleDisplayMode(.inline)
+          .environmentObject(router)
+      }
       .environmentObject(router)
   }
 }

--- a/winston/modifiers/defaultNavDestinations.swift
+++ b/winston/modifiers/defaultNavDestinations.swift
@@ -45,12 +45,6 @@ extension View {
         UserView(user: user)
           .environmentObject(router)
       }
-      .navigationDestination(for: SafariViewPayload.self) { payload in
-        SafariView(payload: payload)
-          .frame(maxHeight: .infinity)
-          .navigationBarTitleDisplayMode(.inline)
-          .environmentObject(router)
-      }
       .environmentObject(router)
   }
 }

--- a/winston/views/Settings/views/BehaviorPanel.swift
+++ b/winston/views/Settings/views/BehaviorPanel.swift
@@ -23,6 +23,8 @@ struct BehaviorPanel: View {
   @Default(.autoPlayVideos) var autoPlayVideos
   @Default(.loopVideos) private var loopVideos
   @Default(.lightboxViewsPost) private var lightboxViewsPost
+  @Default(.useIntegratedBrowser) var useIntegratedBrowser
+  @Default(.defaultReaderMode) var defaultReaderMode
   
   var body: some View {
     List {
@@ -38,6 +40,13 @@ struct BehaviorPanel: View {
           Text("Subscription List").tag("subList")
         }
         .pickerStyle(DefaultPickerStyle())
+      }
+      
+      Section {
+        Toggle("Use integrated browser", isOn: $useIntegratedBrowser)
+        Toggle("Default browser to reader mode", isOn: $defaultReaderMode)
+      } footer: {
+        Text("Instead of opening links in Safari, you can open them inside winston's own browser. If you prefer, the integrated browser can also automatically use reader mode (when available) for a cleaner reading experience.")
       }
       
       Section {

--- a/winston/views/WebView.swift
+++ b/winston/views/WebView.swift
@@ -22,12 +22,12 @@ var dismissHandler: DoneButtonHandler?
 
 struct SafariView: UIViewControllerRepresentable {
   
-  @EnvironmentObject private var router: Router
+  @EnvironmentObject private var routerProxy: RouterProxy
   
   let payload:  SafariViewPayload
   
   func goBack() {
-    router.path.removeLast()
+    routerProxy.router.path.removeLast()
   }
   
 

--- a/winston/views/WebView.swift
+++ b/winston/views/WebView.swift
@@ -1,0 +1,44 @@
+import SafariServices
+import SwiftUI
+
+struct SafariViewPayload: Hashable {
+  let url: URL
+  let useReader: Bool
+}
+
+class DoneButtonHandler: NSObject, SFSafariViewControllerDelegate {
+  var dismissAction: (() -> ())? = nil
+
+  init(dismissAction: @escaping () -> ()) {
+    self.dismissAction = dismissAction
+  }
+  
+  func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+    dismissAction?()
+  }
+}
+
+var dismissHandler: DoneButtonHandler?
+
+struct SafariView: UIViewControllerRepresentable {
+  
+  @EnvironmentObject private var router: Router
+  
+  let payload:  SafariViewPayload
+  
+  func goBack() {
+    router.path.removeLast()
+  }
+  
+
+  func makeUIViewController(context: UIViewControllerRepresentableContext<SafariView>) -> SFSafariViewController {
+    let config = SFSafariViewController.Configuration()
+    config.entersReaderIfAvailable = payload.useReader
+    let vc = SFSafariViewController(url: payload.url, configuration: config)
+    dismissHandler = DoneButtonHandler(dismissAction: goBack)
+    vc.delegate = dismissHandler
+    return vc
+  }
+
+  func updateUIViewController(_ uiViewController: SFSafariViewController, context: UIViewControllerRepresentableContext<SafariView>) {}
+}


### PR DESCRIPTION
Use `SFSafariViewController` to add integrated browser

Caveats:
* currently only works with `PreviewLink` type posts, not ones where only a tappable URL is shown
* Doesn't hide the nav bar or tab bars, which I think would be nice
* There's no way to remove the `Done` button with `SFSafariViewController`... even though it's redundant, I made it work, but it's kinda tacky