### PR TITLE
Add tasks to upvote / downvote for comments

### DIFF
--- a/winston/components/Links/CommentLink/CommentLinkContent.swift
+++ b/winston/components/Links/CommentLink/CommentLinkContent.swift
@@ -125,17 +125,22 @@ struct CommentLinkContent: View {
               HStack(alignment: .center, spacing: 4) {
                 Image(systemName: "arrow.up")
                   .foregroundColor(data.likes != nil && data.likes! ? .orange : .gray)
-                
+                  .onTapGesture {
+                      Task { _ = await comment.vote(action: .up) }
+                  }
+                  
                 let downup = Int(ups - downs)
                 Text(formatBigNumber(downup))
                   .foregroundColor(data.likes != nil ? (data.likes! ? .orange : .blue) : .gray)
                   .contentTransition(.numericText())
-                
                 //                  .foregroundColor(downup == 0 ? .gray : downup > 0 ? .orange : .blue)
                   .fontSize(14, .semibold)
                 
                 Image(systemName: "arrow.down")
                   .foregroundColor(data.likes != nil && !data.likes! ? .blue : .gray)
+                  .onTapGesture {
+                      Task { _ = await comment.vote(action: .down) }
+                  }
               }
               .fontSize(14, .medium)
               .padding(.horizontal, 6)


### PR DESCRIPTION
As per issue #68 this adds in the ability to tap to vote on comments.

As you can see code is fairly simple, adds a onTapGesture to upvote / downvote depending on which arrow is tapped :)) 
When you tap the up arrow, it either upvotes or removes upvote depending on what is toggled. Likewise same behaviour for the downvote button. 

When pressing on the number of upvotes / score or anywhere else, comment still collapses as before. I've done some testing and my changes seem to function as expected. 

I haven't added any extra animation to pressing the button, ie no bounce effect, however, the number of comment votes does still change colour as expected the number of votes will visibly increase / decrease. 

This is my first time creating a pull request on a open source project, so if theres any feedback or things to change, please let me know 😄 